### PR TITLE
Tweaks for configure script

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^CRAN-RELEASE$
 ^update_emoji_codes\.R$
 ^revdep
+^configure.log$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/*.so
 src/*/*.o
 src/Makevars
 inst/doc
+configure.log

--- a/cleanup
+++ b/cleanup
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm -f src/Makevars
+rm -f src/Makevars configure.log

--- a/configure
+++ b/configure
@@ -1,5 +1,5 @@
-#!/bin/bash
-# Anticonf (tm) script by Jeroen Ooms (2019)
+#!/usr/bin/env bash
+# Anticonf (tm) script by Jeroen Ooms (2020)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting
 # INCLUDE_DIR and LIB_DIR manually via e.g:
@@ -53,12 +53,12 @@ CFLAGS=$(${R_HOME}/bin/R CMD config CFLAGS)
 CPPFLAGS=$(${R_HOME}/bin/R CMD config CPPFLAGS)
 
 # Test configuration
-echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null
+echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
 
 # Customize the error
 if [ $? -ne 0 ]; then
-  echo "------------------------- ANTICONF ERROR ---------------------------"
-  echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"
+  echo "--------------------------- [ANTICONF] --------------------------------"
+  echo "Configuration failed to find the $PKG_CONFIG_NAME library. Try installing:"
   echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
   echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
   echo " * csw: $PKG_CSW_NAME (Solaris)"
@@ -67,8 +67,10 @@ if [ $? -ne 0 ]; then
   echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
   echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
   echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+  echo "-------------------------- [ERROR MESSAGE] ---------------------------"
+  cat configure.log
   echo "--------------------------------------------------------------------"
-  exit 1;
+  exit 1
 fi
 
 # Write to Makevars


### PR DESCRIPTION
Some small tweaks including a fix for the cran NOTE: `‘configure’: /bin/bash is not portable` ...