### PR TITLE
remove R.h include

### DIFF
--- a/src/emoji.h
+++ b/src/emoji.h
@@ -5,7 +5,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 #include "utils.h"
 #include "systemfonts.h"

--- a/src/font_metrics.cpp
+++ b/src/font_metrics.cpp
@@ -1,6 +1,5 @@
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 #include <cstdint>

--- a/src/font_metrics.h
+++ b/src/font_metrics.h
@@ -5,7 +5,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 #include "ft_cache.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,6 +1,5 @@
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>

--- a/src/string_metrics.cpp
+++ b/src/string_metrics.cpp
@@ -1,6 +1,5 @@
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 #include "string_metrics.h"

--- a/src/string_metrics.h
+++ b/src/string_metrics.h
@@ -3,7 +3,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 SEXP get_string_shape(SEXP string, SEXP id, SEXP path, SEXP index, SEXP size, 

--- a/src/systemfonts.cpp
+++ b/src/systemfonts.cpp
@@ -3,7 +3,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 #include <R_ext/GraphicsEngine.h>
 

--- a/src/systemfonts.h
+++ b/src/systemfonts.h
@@ -9,7 +9,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 typedef std::pair<std::string, unsigned int> FontLoc;

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,7 +8,6 @@
 
 #define R_NO_REMAP
 
-#include <R.h>
 #include <Rinternals.h>
 
 // Define a C++ try-catch macro to guard C++ calls


### PR DESCRIPTION
You don't need the full R.h api; it is redundant because`Rinternals.h` suffices. On some systems `R.h` creates conflicts with some of your other includes.

With this patch. it works on my Solaris vm.