### PR TITLE
restore compatibility with freetype2 <= 2.4.11

### DIFF
--- a/src/ft_cache.cpp
+++ b/src/ft_cache.cpp
@@ -332,7 +332,7 @@ std::string FreetypeCache::cur_name() {
 }
 
 int FreetypeCache::get_weight() {
-  void* table = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
+  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
   if (table == NULL) {
     return 0;
   }
@@ -341,7 +341,7 @@ int FreetypeCache::get_weight() {
 }
 
 int FreetypeCache::get_width() {
-  void* table = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
+  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
   if (table == NULL) {
     return 0;
   }

--- a/src/ft_cache.cpp
+++ b/src/ft_cache.cpp
@@ -332,7 +332,7 @@ std::string FreetypeCache::cur_name() {
 }
 
 int FreetypeCache::get_weight() {
-  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
+  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2); // [1] ft_sfnt_os2 is deprecated and should be replaced by FT_SFNT_OS2 (only) in the remote future for compatibilty (2021-03-04)
   if (table == NULL) {
     return 0;
   }
@@ -341,7 +341,7 @@ int FreetypeCache::get_weight() {
 }
 
 int FreetypeCache::get_width() {
-  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
+  void* table = FT_Get_Sfnt_Table(face, ft_sfnt_os2); // see comment [1] above
   if (table == NULL) {
     return 0;
   }


### PR DESCRIPTION
As noted by  @dangulod in #70 , using `FT_SFNT_OS2` instead of the deprecated `ft_sfnt_os2` breaks compatibility with older versions of freetype2 but `ft_sfnt_os2` will probably continue to work with newer versions for a while. This PR restores compatibility with freetype2 <= 2.4.11 by switching to `ft_sfnt_os2`  and ads a note to the affected source code.
