### PR TITLE
use .empty() instead of .size()==0

### DIFF
--- a/src/font_registry.cpp
+++ b/src/font_registry.cpp
@@ -82,7 +82,7 @@ data_frame_w registry_fonts_c() {
       }
       weight[i] = 1 + (int) (j == 1 || j == 3);
       italic[i] = (Rboolean) (j > 1);
-      if (it->second.features.size() == 0) {
+      if (it->second.features.empty()) {
         features[i] = integers_w();
       } else {
         int n_features = it->second.features.size();


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html