### PR TITLE
Fix segfault when no system fonts are found on Linux

### DIFF
--- a/src/unix/FontManagerLinux.cpp
+++ b/src/unix/FontManagerLinux.cpp
@@ -226,7 +226,7 @@ FontDescriptor *findFont(FontDescriptor *desc) {
 
   FcResult result;
   FcPattern *font = FcFontMatch(NULL, pattern, &result);
-  FontDescriptor *res = createFontDescriptor(font);
+  FontDescriptor *res = font ? createFontDescriptor(font) : NULL;
 
   FcPatternDestroy(pattern);
   FcPatternDestroy(font);
@@ -263,7 +263,7 @@ FontDescriptor *substituteFont(char *postscriptName, char *string) {
   // find the best match font
   FcResult result;
   FcPattern *font = FcFontMatch(NULL, pattern, &result);
-  FontDescriptor *res = createFontDescriptor(font);
+  FontDescriptor *res = font ? createFontDescriptor(font) : NULL;
 
   FcPatternDestroy(pattern);
   FcPatternDestroy(font);


### PR DESCRIPTION
`FcFontMatch()` returns NULL if no fonts are found, and the old code would
create an invalid FontDescriptor in that case (`res->path` would be NULL).

This causes a segfault in [locate_systemfont()](../blob/v1.0.4/src/font_matching.cpp#L68) because it assumes that
a non-null FontDescriptor returned from `findFont()` is always valid.