### PR TITLE
skip otf fonts on Mac

### DIFF
--- a/src/mac/FontManagerMac.mm
+++ b/src/mac/FontManagerMac.mm
@@ -43,23 +43,27 @@ void addFontIndex(FontDescriptor* font) { @autoreleasepool {
   std::map<std::string, int>::iterator it = font_index.find(font_name);
   if (it == font_index.end()) {
     NSString *font_path = [NSString stringWithUTF8String:font->path];
-    NSURL *font_url = [NSURL fileURLWithPath: font_path];
-    CFArrayRef font_descriptors = CTFontManagerCreateFontDescriptorsFromURL((CFURLRef) font_url);
-    int n_fonts = CFArrayGetCount(font_descriptors);
-    if (n_fonts == 1) {
-      font_no = 0;
-      font_index[font_name] = 0;
-    } else {
-      for (int i = 0; i < n_fonts; i++) {
-        CTFontDescriptorRef font_at_i = (CTFontDescriptorRef) CFArrayGetValueAtIndex(font_descriptors, i);
-        std::string font_name_at_i = [(__bridge_transfer NSString *) CTFontDescriptorCopyAttribute(font_at_i, kCTFontNameAttribute) UTF8String];
-        font_index[font_name_at_i] = i;
-        if (font_name.compare(font_name_at_i) == 0) {
-          font_no = i;
+    NSString *documentExtension = [font_path pathExtension];
+    // NSLog(documentExtension);
+    if (![documentExtension isEqualToString:@"otf"]) {
+      NSURL *font_url = [NSURL fileURLWithPath: font_path];
+      CFArrayRef font_descriptors = CTFontManagerCreateFontDescriptorsFromURL((CFURLRef) font_url);
+      int n_fonts = CFArrayGetCount(font_descriptors);
+      if (n_fonts == 1) {
+        font_no = 0;
+        font_index[font_name] = 0;
+      } else {
+        for (int i = 0; i < n_fonts; i++) {
+          CTFontDescriptorRef font_at_i = (CTFontDescriptorRef) CFArrayGetValueAtIndex(font_descriptors, i);
+          std::string font_name_at_i = [(__bridge_transfer NSString *) CTFontDescriptorCopyAttribute(font_at_i, kCTFontNameAttribute) UTF8String];
+          font_index[font_name_at_i] = i;
+          if (font_name.compare(font_name_at_i) == 0) {
+            font_no = i;
+          }
         }
       }
+      CFRelease(font_descriptors);
     }
-    CFRelease(font_descriptors);
   } else {
     font_no = (*it).second;
   }


### PR DESCRIPTION
This fixes a crash I'm seeing with `otf` fonts. No clue if this is the correct fix or why it is happening. It might be related to the Ventura update.

```
> systemfonts::system_fonts()
 *** caught segfault ***
address 0x0, cause 'invalid permissions'

Traceback:
 1: system_fonts_c()
 2: systemfonts::system_fonts()
```

The fonts causing the crash:
```
2023-04-20 02:25:00.519 rsession-arm64[31778:705261] otf
2023-04-20 02:25:00.519 rsession-arm64[31778:705261] /System/Library/AssetsV2/com_apple_MobileAsset_Font7/a8805b853edf89283dec908153a0015bdd1d00f8.asset/AssetData/WeibeiSC-Bold.otf
2023-04-20 02:25:00.523 rsession-arm64[31778:705261] otf
2023-04-20 02:25:00.523 rsession-arm64[31778:705261] /System/Library/Fonts/Supplemental/STIXTwoMath.otf
2023-04-20 02:25:00.550 rsession-arm64[31778:705261] otf
2023-04-20 02:25:00.550 rsession-arm64[31778:705261] /System/Library/AssetsV2/com_apple_MobileAsset_Font7/0c723883d13f8442faf3adb131fc1eb91c7a1bf1.asset/AssetData/WeibeiTC-Bold.otf
```
