### PR TITLE
Fix building for Wasm/webR when cross-compiling with Emscripten

### DIFF
--- a/src/ft_cache.h
+++ b/src/ft_cache.h
@@ -11,6 +11,11 @@
 #include FT_TYPES_H
 #include FT_SIZES_H
 #include FT_TRUETYPE_TABLES_H
+
+#ifdef __EMSCRIPTEN__
+#undef TYPEOF
+#endif
+
 #include "cache_lru.h"
 
 struct FaceID {

--- a/src/string_shape.h
+++ b/src/string_shape.h
@@ -7,6 +7,11 @@
 #include FT_FREETYPE_H
 #include FT_TYPES_H
 #include FT_CACHE_H
+
+#ifdef __EMSCRIPTEN__
+#undef TYPEOF
+#endif
+
 #include "utils.h"
 #include "ft_cache.h"
 


### PR DESCRIPTION
This PR fixes a few issues when building `systemfonts` for Wasm using Emscripten.

~~1. The `configure` script has been updated to detect cross-compiling to WebAssembly with Emscripten and sets `--static` for `pkg-config` if so, adding some otherwise missing library link flags.~~

~~2. The result of `uname` is overridden to `"Emscripten"` when cross-compiling to Wasm so as to avoid problems when compiling on macOS. In this situation we don't want the Darwin specific code paths in `configure` to run.~~

3. Emscripten's Wasm port of Freetype uses an older upstream source that sets a macro named `TYPEOF` in its headers. This conflicts with R's C API `TYPEOF` macro. Later versions of Freetype>=2.6.2 renamed this macro to `FT_TYPEOF`. We don't need the Freetype macro, so if we're compiling under Emscripten explicitly `undef` it so that it can then be used by R.

