### PR TITLE
guard against bad CTFontManagerCreateFontDescriptorsFromURL return value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
   `match_fonts()`
 * Two internal functions for converting weight and width names to integers have
   been exported
+* Fix a segfault on macOS when the system encounters a corrupted font collection 
+  (#113)
 
 # systemfonts 1.0.6
 

--- a/cleanup
+++ b/cleanup
@@ -1,2 +1,3 @@
 #!/bin/sh
 rm -f src/Makevars configure.log
+rm -Rf .deps

--- a/src/mac/FontManagerMac.mm
+++ b/src/mac/FontManagerMac.mm
@@ -45,21 +45,26 @@ void addFontIndex(FontDescriptor* font) { @autoreleasepool {
     NSString *font_path = [NSString stringWithUTF8String:font->path];
     NSURL *font_url = [NSURL fileURLWithPath: font_path];
     CFArrayRef font_descriptors = CTFontManagerCreateFontDescriptorsFromURL((CFURLRef) font_url);
-    int n_fonts = CFArrayGetCount(font_descriptors);
-    if (n_fonts == 1) {
-      font_no = 0;
-      font_index[font_name] = 0;
+    if (font_descriptors == NULL) {
+      font_no = -1;
+      font_index[font_name] = -1;
     } else {
-      for (int i = 0; i < n_fonts; i++) {
-        CTFontDescriptorRef font_at_i = (CTFontDescriptorRef) CFArrayGetValueAtIndex(font_descriptors, i);
-        std::string font_name_at_i = [(__bridge_transfer NSString *) CTFontDescriptorCopyAttribute(font_at_i, kCTFontNameAttribute) UTF8String];
-        font_index[font_name_at_i] = i;
-        if (font_name.compare(font_name_at_i) == 0) {
-          font_no = i;
+      int n_fonts = CFArrayGetCount(font_descriptors);
+      if (n_fonts == 1) {
+        font_no = 0;
+        font_index[font_name] = 0;
+      } else {
+        for (int i = 0; i < n_fonts; i++) {
+          CTFontDescriptorRef font_at_i = (CTFontDescriptorRef) CFArrayGetValueAtIndex(font_descriptors, i);
+          std::string font_name_at_i = [(__bridge_transfer NSString *) CTFontDescriptorCopyAttribute(font_at_i, kCTFontNameAttribute) UTF8String];
+          font_index[font_name_at_i] = i;
+          if (font_name.compare(font_name_at_i) == 0) {
+            font_no = i;
+          }
         }
       }
+      CFRelease(font_descriptors);
     }
-    CFRelease(font_descriptors);
   } else {
     font_no = (*it).second;
   }

--- a/src/mac/FontManagerMac.mm
+++ b/src/mac/FontManagerMac.mm
@@ -46,8 +46,8 @@ void addFontIndex(FontDescriptor* font) { @autoreleasepool {
     NSURL *font_url = [NSURL fileURLWithPath: font_path];
     CFArrayRef font_descriptors = CTFontManagerCreateFontDescriptorsFromURL((CFURLRef) font_url);
     if (font_descriptors == NULL) {
-      font_no = -1;
-      font_index[font_name] = -1;
+      font_no = 0;
+      font_index[font_name] = 0;
     } else {
       int n_fonts = CFArrayGetCount(font_descriptors);
       if (n_fonts == 1) {


### PR DESCRIPTION
Fix #113 

`CTFontManagerCreateFontDescriptorsFromURL()` may return `NULL` on error resulting in a segfault on the following call