### PR TITLE
Skip tests on FreeBSD that are non-deterministic.

### DIFF
--- a/tests/testthat/test-match_font.R
+++ b/tests/testthat/test-match_font.R
@@ -15,6 +15,7 @@ test_that("Font files can be found", {
   expect_true(file.exists(font_path))
 
   skip_on_os("linux") # Different fonts for different distros
+  skip_on_os("freebsd") # Different fonts for different users
   skip_on_os("solaris") # Have no idea what it is supposed to give
   expect_equal(tools::file_path_sans_ext(basename(font_path)), font)
 })
@@ -25,6 +26,7 @@ test_that("Default font is correct", {
   expect_true(file.exists(font_path))
 
   skip_on_os("linux")
+  skip_on_os("freebsd")
   skip_on_os("solaris")
   expect_equal(tools::file_path_sans_ext(basename(font_path)), font)
 })


### PR DESCRIPTION
Different users have different outcomes.